### PR TITLE
Slack doesn't display ASCII responses properly

### DIFF
--- a/lib/lita/handlers/ascii_art.rb
+++ b/lib/lita/handlers/ascii_art.rb
@@ -13,7 +13,12 @@ module Lita
         response.matches.first.each do |c|
           s += @@art.asciify(c)
         end
-        response.reply s
+        case robot.config.robot.adapter
+        when :slack
+          response.reply "```" + s + "```"
+        else
+          response.reply s
+        end
       end
     end
 


### PR DESCRIPTION
Wrap ASCII responses in Slack's blockquote syntax if :slack adapter is in use.
